### PR TITLE
Avoid javascript runtime error when no country is found for coordinates.

### DIFF
--- a/scenemodels/inc/js/update_objects.js
+++ b/scenemodels/inc/js/update_objects.js
@@ -111,6 +111,10 @@ function update_country_aux(hreq, country_id)
 {
     if (hreq.readyState == 4) //checks that the request is finished       
     {
+        if (hreq.responseXML.getElementsByTagName("country")[0].childNodes.length == 0) {
+            // no country found/returned. Leave country selection unchanged
+            return;
+        }
         var country=hreq.responseXML.getElementsByTagName("country")[0].childNodes[0].nodeValue;
 
         var ddl = document.getElementById(country_id);


### PR DESCRIPTION
The error is only seen with a JS console open, but anyway.