### PR TITLE
Additional attributes 'Usage' and 'Token' for scenery objects.

### DIFF
--- a/scenemodels/classes/ObjectFactory.php
+++ b/scenemodels/classes/ObjectFactory.php
@@ -31,7 +31,7 @@ class ObjectFactory {
     }
     
     public function createObject($id, $modelId, $lon, $lat, $countryCode,
-            $elevOffset, $orientation, $group, $desc) {
+            $elevOffset, $orientation, $group, $desc, $usageId = 0, $tokenId = 0) {
         $country = $this->objectDaoRO->getCountry($countryCode);
         
         $object = new \model\TheObject();
@@ -45,7 +45,8 @@ class ObjectFactory {
         $object->getPosition()->setOrientation($orientation);
         $object->setDescription($desc);
         $object->setGroupId($group);
-        
+        $object->setUsageId($usageId);
+        $object->setTokenId($tokenId);
         return $object;
     }
 }

--- a/scenemodels/classes/controller/AddModelController.php
+++ b/scenemodels/classes/controller/AddModelController.php
@@ -40,12 +40,14 @@ class AddModelController extends ModelRequestController {
      */
     public function formAction() {
         parent::menu();
-        
+
         // Show all the families other than the static family
         $modelsGroups = $this->getModelsGroups();
         $countries = $this->objectDaoRO->getCountries();
         $nbModels = $this->getModelDaoRO()->countTotalModels();
         $authors = $this->authorDaoRO->getAllAuthors(0, "ALL");
+        $usages = \model\TheObject::usages();
+        $tokens = \model\TheObject::tokens();
 
         include 'view/submission/model/add_model_form.php';
     }
@@ -59,7 +61,7 @@ class AddModelController extends ModelRequestController {
         
         /** STEP 1 : CHECK IF ALL FILES WERE RECEIVED */
         $exceptions = $this->checkFilesArray();
-        
+
         /** STEP 2 : MOVE THUMBNAIL, AC3D, PNG AND XML FILES IN TMP DIRECTORY (Will be removed later on) */
         $thumbName = $_FILES['mo_thumbfile']['name'];
         $ac3dName  = $_FILES['ac3d_file']['name'];
@@ -127,6 +129,10 @@ class AddModelController extends ModelRequestController {
         $offset    = strip_tags($this->getVar('offset'));
         $heading   = strip_tags($this->getVar('heading'));
         $country   = $this->getVar('ob_country');
+        $country   = $this->getVar('ob_country');
+        $usageId  = $this->getVar('ob_usage_id');
+        $tokenId  = $this->getVar('ob_token_id');
+
         $objectValidator = \submission\ObjectValidator::getPositionValidator($longitude, $latitude, $country, $offset, $heading);
 
         $validatorsSet = new \submission\ValidatorsSet();
@@ -183,7 +189,7 @@ class AddModelController extends ModelRequestController {
         $newModel->setThumbnail($thumbFile);
 
         $newObject = $objectFactory->createObject(-1, -1, $longitude, $latitude, $country, 
-                $offset, \ObjectUtils::headingSTG2True($heading), 1, $name);
+                $offset, \ObjectUtils::headingSTG2True($heading), 1, $name, $usageId, $tokenId);
 
         // Check captcha
         if (!$this->checkCaptcha()) {

--- a/scenemodels/classes/controller/AddModelValidatorController.php
+++ b/scenemodels/classes/controller/AddModelValidatorController.php
@@ -48,7 +48,9 @@ class AddModelValidatorController extends ValidatorController {
                 // Check first if the author already exist
                 $authorExist = $this->authorDaoRO->getAuthorByEmail($newAuthor->getEmail()) != null;
             }
-            
+            $usages = \model\TheObject::usages();
+            $tokens = \model\TheObject::tokens();
+
             include 'view/submission/model/validator/view_add_model_request.php';
         }
     }

--- a/scenemodels/classes/controller/ObjectValidatorController.php
+++ b/scenemodels/classes/controller/ObjectValidatorController.php
@@ -28,6 +28,8 @@ namespace controller;
 class ObjectValidatorController extends ValidatorController {
     public function viewRequestAction() {
         $request = $this->getRequest();
+        $usages = \model\TheObject::usages();
+        $tokens = \model\TheObject::tokens();
         if ($request != null) {
             include 'view/submission/object/validator/object_submission.php';
         }

--- a/scenemodels/classes/controller/ObjectsController.php
+++ b/scenemodels/classes/controller/ObjectsController.php
@@ -44,6 +44,8 @@ class ObjectsController extends ControllerMenu {
             $object = $this->objectDaoRO->getObject($id);
             $modelMetadata = $this->getModelDaoRO()->getModelMetadata($object->getModelId());
             $group = $this->objectDaoRO->getObjectsGroup($object->getGroupId());
+            $usages = \model\TheObject::usages();
+            $tokens = \model\TheObject::tokens();
             include 'view/objectview.php';
         } else {
             $pageTitle = "Object ID not valid";

--- a/scenemodels/classes/controller/UpdateObjectsController.php
+++ b/scenemodels/classes/controller/UpdateObjectsController.php
@@ -118,6 +118,8 @@ class UpdateObjectsController extends RequestController {
         if (\FormChecker::isLongitude($this->getVar('lon'))) {
             $defaultLon = $this->getVar('lon');
         }
+        $usages = \model\TheObject::usages();
+        $tokens = \model\TheObject::tokens();
         
         include 'view/submission/object/update_object_form.php';
     }
@@ -144,7 +146,9 @@ class UpdateObjectsController extends RequestController {
         $new_offset = $this->getVar('new_offset');
         $new_orientation = $this->getVar('new_heading');
         $safe_new_ob_text = $this->getVar('new_ob_text');
-        
+        $new_usageId = $this->getVar('new_usage_id');
+        $new_tokenId = $this->getVar('new_token_id');
+
         $idToUpdate = $this->getVar('id_to_update');
         if (!\FormChecker::isObjectId($idToUpdate)) {
             $pageTitle = 'Objects update Form';
@@ -178,7 +182,8 @@ class UpdateObjectsController extends RequestController {
             $oldObject = $this->objectDaoRO->getObject($idToUpdate);
             $newObject = $objectFactory->createObject($idToUpdate, $modelId,
                     $new_long, $new_lat, $new_country, 
-                    $new_offset, \ObjectUtils::headingSTG2True($new_orientation), 1, $safe_new_ob_text);
+                    $new_offset, \ObjectUtils::headingSTG2True($new_orientation), 1, $safe_new_ob_text,
+                    $new_usageId, $new_tokenId);
 
             $oldModelMD = $this->getModelDaoRO()->getModelMetadata($oldObject->getModelId());
             $newModelMD = $this->getModelDaoRO()->getModelMetadata($modelId);

--- a/scenemodels/classes/dao/ObjectDAO.php
+++ b/scenemodels/classes/dao/ObjectDAO.php
@@ -17,11 +17,12 @@ class ObjectDAO extends PgSqlDAO implements IObjectDAO {
         $objPos = $obj->getPosition();
         $obOffset = $objPos->getElevationOffset();
         
-        $query = "INSERT INTO fgs_objects (ob_id, ob_text, wkb_geometry, ob_gndelev, ob_elevoffset, ob_heading, ob_country, ob_model, ob_group) ".
+        $query = "INSERT INTO fgs_objects (ob_id, ob_text, wkb_geometry, ob_gndelev, ob_elevoffset, ob_heading, ob_country, ob_model, ob_usage, ob_token, ob_group) ".
                 "VALUES (DEFAULT, '".pg_escape_string($obj->getDescription())."', ST_PointFromText('POINT(".pg_escape_string($objPos->getLongitude())." ".pg_escape_string($objPos->getLatitude()).")', 4326), -9999, ".
                 (($obOffset == 0 || $obOffset == '')?"NULL":pg_escape_string($obOffset)) .
-                ", ".pg_escape_string($objPos->getOrientation()).", '".pg_escape_string($obj->getCountry()->getCode())."', ".pg_escape_string($obj->getModelId()).", 1) RETURNING ob_id;";
-    
+                ", ".pg_escape_string($objPos->getOrientation()).", '".pg_escape_string($obj->getCountry()->getCode())."', ".pg_escape_string($obj->getModelId()).
+                ", ".pg_escape_string($obj->getUsageId()).", ".pg_escape_string($obj->getTokenId()).", 1) RETURNING ob_id;";
+
         $result = $this->database->query($query);
         
         if (!$result) {
@@ -40,8 +41,10 @@ class ObjectDAO extends PgSqlDAO implements IObjectDAO {
                  "SET ob_text=$$".pg_escape_string($object->getDescription())."$$, ".
                  "wkb_geometry=ST_PointFromText('POINT(".pg_escape_string($objPos->getLongitude())." ".pg_escape_string($objPos->getLatitude()).")', 4326),".
                  "ob_country='".pg_escape_string($object->getCountry()->getCode())."',".
-                 "ob_gndelev=-9999, ob_elevoffset=".pg_escape_string($objPos->getElevationOffset()).", ob_heading=".pg_escape_string($objPos->getOrientation()).", ob_model=".pg_escape_string($object->getModelId()).", ob_group=1 ".
-                 "WHERE ob_id=".pg_escape_string($object->getId()).";";
+                 "ob_gndelev=-9999, ob_elevoffset=".pg_escape_string($objPos->getElevationOffset()).", ob_heading=".pg_escape_string($objPos->getOrientation()).", ob_model=".pg_escape_string($object->getModelId()).", ".
+                 "ob_usage=".pg_escape_string($object->getUsageId()).",".
+                 "ob_token=".pg_escape_string($object->getTokenId()).",".
+                 "ob_group=1 WHERE ob_id=".pg_escape_string($object->getId()).";";
         
         $result = $this->database->query($query);
         
@@ -203,7 +206,9 @@ class ObjectDAO extends PgSqlDAO implements IObjectDAO {
         $object->setDescription($objectRow['ob_text']);
         $object->setGroupId($objectRow['ob_group']);
         $object->setLastUpdated(new \DateTime($objectRow['ob_modified']));
-        
+        $object->setUsageId($objectRow['ob_usage']);
+        $object->setTokenId($objectRow['ob_token']);
+
         return $object;
     }
     

--- a/scenemodels/classes/dao/RequestDAO.php
+++ b/scenemodels/classes/dao/RequestDAO.php
@@ -136,7 +136,9 @@ class RequestDAO extends PgSqlDAO implements IRequestDAO {
                      'offset'=>(empty($offset)?'NULL':$offset),
                      'orientation'=>$objPos->getOrientation(),
                      'country'=>$object->getCountry()->getCode(),
-                     'modelId'=>$object->getModelId());
+                     'modelId'=>$object->getModelId(),
+                     'usageId'=>$object->getUsageId(),
+                     'tokenId'=>$object->getTokenId());
     }
     
     private function arrayRequestObjectUpdate($request) {
@@ -151,7 +153,9 @@ class RequestDAO extends PgSqlDAO implements IRequestDAO {
                      'orientation'=>$newObjPos->getOrientation(),
                      'country'=>$newObj->getCountry()->getCode(),
                      'modelId'=>$newObj->getModelId(),
-                     'objectId'=>$newObj->getId());
+                     'objectId'=>$newObj->getId(),
+                     'usageId'=>$newObj->getUsageId(),
+                     'tokenId'=>$newObj->getTokenId());
     }
     
     private function arrayRequestObjectDelete($request) {
@@ -365,7 +369,8 @@ class RequestDAO extends PgSqlDAO implements IRequestDAO {
         
         return $objectFactory->createObject(-1, $addReqArray['modelId'],
                $addReqArray['longitude'], $addReqArray['latitude'], $addReqArray['country'], 
-               $addReqArray['offset'], $addReqArray['orientation'], 1, $addReqArray['description']);
+               $addReqArray['offset'], $addReqArray['orientation'], 1, $addReqArray['description'],
+               $addReqArray['usageId'], $addReqArray['tokenId']);
     }
     
     private function getRequestMassiveObjectsAddFromRow($objRequests) {
@@ -387,7 +392,8 @@ class RequestDAO extends PgSqlDAO implements IRequestDAO {
 
         $newObject = $objectFactory->createObject($updReqArray['objectId'], $updReqArray['modelId'],
                $updReqArray['longitude'], $updReqArray['latitude'], $updReqArray['country'], 
-               $updReqArray['offset'], $updReqArray['orientation'], 1, $updReqArray['description']);
+               $updReqArray['offset'], $updReqArray['orientation'], 1, $updReqArray['description'],
+               $updReqArray['usageId'],$updReqArray['tokenId']);
 
         $requestObjUp = new \model\RequestObjectUpdate();
         $requestObjUp->setContributorEmail('');

--- a/scenemodels/classes/model/TheObject.php
+++ b/scenemodels/classes/model/TheObject.php
@@ -23,6 +23,8 @@ class TheObject {
     
     private $description;
     private $groupId;
+    private $usageId;
+    private $tokenId;
     
     function __construct() {
         $this->position = new Position();
@@ -92,6 +94,32 @@ class TheObject {
     public function getPosition() {
         return $this->position;
     }
-}
 
+    public function getUsageId() {
+        return $this->usageId;
+    }
+
+    public function setUsageId($usageId) {
+        $this->usageId = $usageId;
+    }
+
+    public function getTokenId() {
+        return $this->tokenId;
+    }
+
+    public function setTokenId($tokenId) {
+        $this->tokenId = $tokenId;
+    }
+
+    /**
+     * static lists of allowed usages and tokens
+     */
+    public static function usages() {
+        return array("<default>", "StaticAircraft", "ApronVehicles","AIObjects");
+    }
+
+    public static function tokens() {
+        return array("<default>", "AI_OBJECT");
+    }
+}
 ?>

--- a/scenemodels/view/objectview.php
+++ b/scenemodels/view/objectview.php
@@ -14,7 +14,7 @@ $objPos = $object->getPosition();
 
 <table>
     <tr>
-        <td style="width: 320px" rowspan="9"><img src="app.php?c=Models&amp;a=thumbnail&amp;id=<?php echo $object->getModelId(); ?>" alt="Thumbnail"/></td>
+        <td style="width: 320px" rowspan="11"><img src="app.php?c=Models&amp;a=thumbnail&amp;id=<?php echo $object->getModelId(); ?>" alt="Thumbnail"/></td>
         <td style="width: 320px">Unique ID</td>
         <td><?php echo $object->getId(); ?></td>
     </tr>
@@ -52,6 +52,14 @@ $objPos = $object->getPosition();
     <tr>
         <td>Group</td>
         <td><?php echo "<a href=\"app.php?c=Objects&amp;a=search&amp;group=".$object->getGroupId()."\">".$group->getName()."</a>"; ?></td>
+    </tr>
+    <tr>
+        <td>Usage</td>
+        <td><?php echo htmlspecialchars($usages[$object->getUsageId()]); ?></td>
+    </tr>
+    <tr>
+        <td>STG Token</td>
+        <td><?php echo htmlspecialchars($tokens[$object->getTokenId()]); ?></td>
     </tr>
     <tr>
         <td>Model</td>

--- a/scenemodels/view/submission/model/add_model_form.php
+++ b/scenemodels/view/submission/model/add_model_form.php
@@ -159,6 +159,44 @@ $(function() {
                     </td>
                 </tr>
                 <tr>
+                    <td style="width: 200px;">
+                        <label for="ob_usage_id">Model's usage<em>*</em><span>This is the usage of the object you want to add while it defines the scenery export directory ("Objects" will be the default). If unsure, don't select a value (keep &lt;default&gt;).</span></label>
+                    </td>
+                    <td>
+                        <select name="ob_usage_id" id="ob_usage_id">
+                            <?php
+                            for ($index = 0; $index < count($usages); $index++) {
+                                $v = htmlspecialchars($usages[$index]);
+                                if ($index == 0) {
+                                    echo "<option value=\"".$index."\" selected=\"selected\">".$v."</option>";
+                                } else {
+                                    echo "<option value=\"".$index."\">".$v."</option>";
+                                }
+                            }
+                            ?>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="width: 200px;">
+                        <label for="ob_token_id">Model's STG token<em>*</em><span>This is the STG token assigned to this object and to be used during scenery export. If unsure, don't select a token (keep &lt;default&gt;) which lets the exporter script decide which token to use.</span></label>
+                    </td>
+                    <td>
+                        <select name="ob_token_id" id="ob_token_id">
+                            <?php
+                            for ($index = 0; $index < count($tokens); $index++) {
+                                $v = htmlspecialchars($tokens[$index]);
+                                if ($index == 0) {
+                                    echo "<option value=\"".$index."\" selected=\"selected\">".$v."</option>";
+                                } else {
+                                    echo "<option value=\"".$index."\">".$v."</option>";
+                                }
+                            }
+                            ?>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
                     <td>
                         <label for="mo_name">Model name<em>*</em><span>Please add a short (max 100 letters) name of your model (eg : Cornet antenna radome - Brittany - France).</span></label>
                     </td>

--- a/scenemodels/view/submission/model/validator/view_add_model_request.php
+++ b/scenemodels/view/submission/model/validator/view_add_model_request.php
@@ -84,6 +84,14 @@ function validateForm() {
             <td><?php echo $newModelMD->getModelsGroup()->getName(); ?></td>
         </tr>
         <tr>
+            <td>Usage</td>
+            <td><?php echo htmlspecialchars($usages[$newObj->getUsageId()]); ?></td>
+        </tr>
+        <tr>
+            <td>STG Token</td>
+            <td><?php echo htmlspecialchars($tokens[$newObj->getTokenId()]); ?></td>
+        </tr>
+        <tr>
             <td>Proposed Path Name</td>
             <td><?php echo $newModelMD->getFilename(); ?></td>
         </tr>

--- a/scenemodels/view/submission/object/update_object_form.php
+++ b/scenemodels/view/submission/object/update_object_form.php
@@ -97,6 +97,47 @@ else {
         </tr>
         <tr>
           <td>
+            <span title="This is the usage of the object you want to update while it defines the scenery export directory ('Objects' will be the default). If unsure, don't select a value (keep &lt;default&gt;)."><label for="new_usage_id">Object's usage<em>*</em></label></span>
+          </td>
+          <td><?php echo htmlspecialchars($usages[$objectToUp->getUsageId()]); ?></td>
+          <td>
+              <select name="new_usage_id" id="new_usage_id">
+              <?php
+              for ($index = 0; $index < count($usages); $index++) {
+                  $v = htmlspecialchars($usages[$index]);
+                  if ($index == $objectToUp->getUsageId()) {
+                      echo "<option value=\"".$index."\" selected=\"selected\">".$v."</option>";
+                  } else {
+                      echo "<option value=\"".$index."\">".$v."</option>";
+                  }
+              }
+              ?>
+              </select>
+          </td>
+        </tr>
+            <tr>
+              <td>
+                <span title="This is the STG token assigned to this object and to be used during scenery export. If unsure, don't select a token (keep &lt;default&gt;) which lets the exporter script decide which token to use.">
+                <label for="new_token_id">Object's STG token<em>*</em></label></span>
+              </td>
+              <td><?php echo htmlspecialchars($tokens[$objectToUp->getTokenId()]); ?></td>
+              <td>
+                  <select name="new_token_id" id="new_token_id">
+                  <?php
+                  for ($index = 0; $index < count($tokens); $index++) {
+                      $v = htmlspecialchars($tokens[$index]);
+                      if ($index == $objectToUp->getTokenId()) {
+                          echo "<option value=\"".$index."\" selected=\"selected\">".$v."</option>";
+                      } else {
+                          echo "<option value=\"".$index."\">".$v."</option>";
+                      }
+                  }
+                  ?>
+                  </select>
+              </td>
+            </tr>
+        <tr>
+          <td>
             <span title="This is the model name of the object you want to update, ie the name as it's supposed to appear in the .stg file.">
             <label for="modelId">Model name<em>*</em></label></span>
           </td>

--- a/scenemodels/view/submission/object/validator/object_submission.php
+++ b/scenemodels/view/submission/object/validator/object_submission.php
@@ -32,6 +32,19 @@ case "model\RequestObjectUpdate":
         echo " style=\"background-color: rgb(255, 200, 0)\"";
     }
     echo "><td>Object's model</td><td>".htmlspecialchars($oldModelMD->getName())."</td><td>".htmlspecialchars($newModelMD->getName())."</td></tr>";
+
+    echo "<tr";
+    if ($oldObject->getUsageId() != $newObject->getUsageId()) {
+        echo " style=\"background-color: rgb(255, 200, 0)\"";
+    }
+    echo "><td>Object's Usage</td><td>".htmlspecialchars($usages[$oldObject->getUsageId()])."</td><td>".htmlspecialchars($usages[$newObject->getUsageId()])."</td></tr>";
+
+    echo "<tr";
+    if ($oldObject->getTokenId() != $newObject->getTokenId()) {
+        echo " style=\"background-color: rgb(255, 200, 0)\"";
+    }
+    echo "><td>Object's STG token</td><td>".htmlspecialchars($tokens[$oldObject->getTokenId()])."</td><td>".htmlspecialchars($tokens[$newObject->getTokenId()])."</td></tr>";
+
     echo "<tr><td>Thumbnail</td><td><img src='app.php?c=Models&amp;a=thumbnail&amp;id=".$oldModelMD->getId()."' alt=''/></td>".
             "<td><img src='app.php?c=Models&amp;a=thumbnail&amp;id=".$newModelMD->getId()."' alt=''/></td></tr>";
     echo "<tr";


### PR DESCRIPTION
This is the result of the mailing list discussion 'Static aircraft'. Two additional database columns are required:

alter table fgs_objects add column ob_usage integer default 0;
alter table fgs_objects add column ob_token integer default 0;

For now the modifications cover the workflow addNewModel->validate->view->update->validate->view.
Adding the fields to search form will come later.

The changes where tested in my local environment. 

Reviewing my own git commit I found a duplicated code line '$country   = $this->getVar('ob_country');'. This doesn't harm and can be removed later.